### PR TITLE
Fix for WebRTC 1.0 Issue 391 A-D in DTMF (and change log additions)

### DIFF
--- a/ortc.html
+++ b/ortc.html
@@ -5684,6 +5684,10 @@ RTCRtpParameters function myCapsToRecvParams(RTCRtpCapabilities recvCaps, RTCRtp
                         <a href="https://github.com/w3c/webrtc-pc/issues/377">Issue 377</a>
                     </li>
                     <li>
+                        Use USVString for datachannel.send(), as noted in:
+                        <a href="https://github.com/w3c/webrtc-pc/pull/387">PR 387</a>
+                    </li>
+                    <li>
                         Clarified requirements for DTMF A-D tone support, as noted in:
                         <a href="https://github.com/w3c/webrtc-pc/issues/391">Issue 391</a>
                     </li>

--- a/ortc.html
+++ b/ortc.html
@@ -3718,6 +3718,8 @@ var encodings = [{
                             character ',' indicates a delay of 2 seconds before processing the
                             next character in the tones parameter. All other characters <em title="MUST" class="rfc2119">MUST</em> be
                             considered <dfn id="dtmf-unrecognized">unrecognized</dfn>.
+                            As noted in [[RTCWEB-AUDIO]] Section 3, support for the characters 0 through 9, #, and *
+                            are required.
                         </p>
                         <p>
                             The duration parameter indicates the duration in ms to use for
@@ -5670,6 +5672,19 @@ RTCRtpParameters function myCapsToRecvParams(RTCRtpCapabilities recvCaps, RTCRtp
             <h2>Change Log</h2>
             <p>This section will be removed before publication.</p>
             <!-- Why do the first two headings automatically convert to <h2>? -->
+            <section id="since-20-November-2015*">
+                <h3>Changes since 20 November 2015</h3>
+                <ol>
+                    <li>
+                        Clarified meaning of audioLevel, as noted in:
+                        <a href="https://github.com/w3c/webrtc-pc/issues/377">Issue 377</a>
+                    </li>
+                    <li>
+                        Clarified requirements for DTMF A-D tone support, as noted in:
+                        <a href="https://github.com/w3c/webrtc-pc/issues/391">Issue 391</a>
+                    </li>
+                </ol>
+            </section>
             <section id="since-05-October-2015*">
                 <h3>Changes since 05 October 2015</h3>
                 <ol>

--- a/ortc.html
+++ b/ortc.html
@@ -5676,6 +5676,10 @@ RTCRtpParameters function myCapsToRecvParams(RTCRtpCapabilities recvCaps, RTCRtp
                 <h3>Changes since 20 November 2015</h3>
                 <ol>
                     <li>
+                        Added definition of maxBitrate, as noted in:
+                        <a href="https://github.com/w3c/webrtc-pc/issues/267">Issue 267</a>
+                    </li>
+                    <li>
                         Clarified meaning of audioLevel, as noted in:
                         <a href="https://github.com/w3c/webrtc-pc/issues/377">Issue 377</a>
                     </li>


### PR DESCRIPTION
The following issue was filed against WebRTC 1.0 relating to DTMF support: 
https://github.com/w3c/webrtc-pc/issues/391

It was resolved in the following PR: 
https://github.com/w3c/webrtc-pc/pull/402