### PR TITLE
H.264 sender settings

### DIFF
--- a/ortc.html
+++ b/ortc.html
@@ -3106,7 +3106,8 @@ mySignaller.myOfferTracks({
                                         <code>unsigned long</code>
                                     </td>
                                     <td>Sender</td>
-                                    <td>This parameter, which describes the maximum capability of the decoder, MUST be supported, as noted in [[!RTCWEB-VIDEO]] Section 6.2.</td>
+                                    <td>This parameter indicates the configuration of the stream to be sent, as noted in [[RFC6184]] Section 8.2.2.
+                                    It MUST be supported, as noted in [[!RTCWEB-VIDEO]] Section 6.2.</td>
                                 </tr>
                                 <tr id="sec-packetization-mode*">
                                     <td><a>packetizationMode</a></td>
@@ -3115,18 +3116,6 @@ mySignaller.myOfferTracks({
                                     <td>
                                         An unsigned short ranging from 0 to 2, indicating the <var>packetizationMode</var> value to be used by the sender.  This setting MUST be
                                         supported, as noted in [[!RTCWEB-VIDEO]] Section 6.2. 
-                                    </td>
-                                </tr>
-                                <tr id="sec-other-h264-params*">
-                                    <td>maxMbps, maxSmbps, maxFs, maxCpb, maxDpb, maxBr</td>
-                                    <td>
-                                        <code>unsigned long long</code>
-                                    </td>
-                                    <td>Sender</td>
-                                    <td>
-                                        These optional parameters allow the implementation to specify that the decoder
-                                        can support certain features of H.264 at higher rates and values than those
-                                        signalled with profile-level-id.
                                     </td>
                                 </tr>
                             </tbody>


### PR DESCRIPTION
H.264 SDP parameters are listed in draft-ietf-rtcweb-video Section 6.2.  RFC 6184 Section 8.2.2 Table 6 indicates how these parameters are to be interpreted for different direction attributes.  Of the parameters listed in draft-ietf-rtcweb-video, only profile-level-id and packetization-mode are listed as a configuration parameter of sent streams.  Therefore only these parameters should be listed as sender settings.

Relates to Issue 258:

https://github.com/openpeer/ortc/issues/258