### PR TITLE
Change of RTCRtpContributingSource from an Interface to a dictionary

### DIFF
--- a/ortc.html
+++ b/ortc.html
@@ -5694,6 +5694,10 @@ RTCRtpParameters function myCapsToRecvParams(RTCRtpCapabilities recvCaps, RTCRtp
                         Clarified requirements for DTMF A-D tone support, as noted in:
                         <a href="https://github.com/w3c/webrtc-pc/issues/391">Issue 391</a>
                     </li>
+                    <li>
+                        Change RTCRtpContributingSource from an interface to a dictionary, as noted in:
+                        <a href="https://github.com/openpeer/ortc/issues/289">Issue 289</a>
+                    </li>
                 </ol>
             </section>
             <section id="since-05-October-2015*">

--- a/ortc.html
+++ b/ortc.html
@@ -1847,8 +1847,8 @@ function accept(mySignaller, remote) {
                     If the RTP packet contains no CSRCs, then the <code><a>RTCRtpContributingSource</a></code> object corresponding to the
                     SSRC is updated, and the level value for the SSRC is updated based on the client-mixer header extension [[!RFC6464]] if present.
                 </p>
-                <dl class="idl" title="interface RTCRtpContributingSource">
-                    <dt>readonly attribute DOMHighResTimeStamp timestamp</dt>
+                <dl class="idl" title="dictionary RTCRtpContributingSource">
+                    <dt>DOMHighResTimeStamp timestamp</dt>
                     <dd>
                         <p>
                             The <var>timestamp</var> of type <code>DOMHighResTimeStamp</code>
@@ -1858,11 +1858,11 @@ function accept(mySignaller, remote) {
                             a local clock.
                         </p>
                     </dd>
-                    <dt>readonly attribute unsigned long source</dt>
+                    <dt>unsigned long source</dt>
                     <dd>
                         <p>The CSRC or SSRC value of the contributing source.</p>
                     </dd>
-                    <dt>readonly attribute byte? audioLevel</dt>
+                    <dt>byte? audioLevel</dt>
                     <dd>
                         <p>
                             The audio level contained in the last RTP packet


### PR DESCRIPTION
Fix for ORTC Issue 289: 
https://github.com/openpeer/ortc/issues/289