### PR TITLE
Cleanup of Opus settings (Issue 258)

### DIFF
--- a/ortc.html
+++ b/ortc.html
@@ -2631,14 +2631,6 @@ mySignaller.myOfferTracks({
                                     <td>Sender</td>
                                     <td>A hint about the maximum input sampling rate that the sender is likely to produce.</td> 
                                 </tr>
-                                <tr id="def-ptime*">
-                                    <td><dfn>ptime</dfn></td>
-                                    <td>
-                                        <code>unsigned long</code>
-                                    </td>
-                                    <td>Receiver</td>
-                                    <td>The preferred duration of media represented by a packet that a decoder wants to receive in milliseconds.</td>
-                                </tr>
                                 <tr id="def-maxaveragebitrate*">
                                     <td><dfn>maxAverageBitrate</dfn></td>
                                     <td>
@@ -2939,14 +2931,6 @@ mySignaller.myOfferTracks({
                                     </td>
                                     <td>Receiver</td>
                                     <td>The maximum input sampling rate produced by the sender.</td>
-                                </tr>
-                                <tr id="sec-opus-ptime*">
-                                    <td><a>ptime</a></td>
-                                    <td>
-                                        <code>unsigned long</code>
-                                    </td>
-                                    <td>Sender</td>
-                                    <td>The duration of media represented by a packet that the encoder will produce in milliseconds.</td>
                                 </tr>
                                 <tr id="sec-cbr*">
                                     <td><a>cbr</a></td>

--- a/ortc.html
+++ b/ortc.html
@@ -2647,22 +2647,6 @@ mySignaller.myOfferTracks({
                                     <td>Receiver</td>
                                     <td>Specifies the maximum average receive bitrate of a session in bits per second (bits/s).</td> 
                                 </tr>
-                                <tr id="def-stereo*">
-                                    <td><dfn>stereo</dfn></td>
-                                    <td>
-                                        <code>boolean</code>
-                                    </td>
-                                    <td>Receiver</td>
-                                    <td>Specifies whether the decoder prefers receiving stereo (if true) or mono signals (if false).</td>
-                                </tr>
-                                <tr id="def-spropstereo*">
-                                    <td><dfn>spropStereo</dfn></td>
-                                    <td>
-                                        <code>boolean</code>
-                                    </td>
-                                    <td>Sender</td>
-                                    <td>Specifies whether the sender is likely to produce stereo audio (if true) or mono signals (if false).</td>
-                                </tr>
                                 <tr id="def-cbr*">
                                     <td><dfn>cbr</dfn></td>
                                     <td>

--- a/ortc.html
+++ b/ortc.html
@@ -2946,7 +2946,7 @@ mySignaller.myOfferTracks({
                                         <code>unsigned long</code>
                                     </td>
                                     <td>Sender</td>
-                                    <td>A hint about the maximum output sampling rate that the receiver is capable of rendering in Hz.</td>
+                                    <td>The maximum output sampling rate of the encoder in Hz.</td>
                                 </tr>
                                 <tr id="sec-sprop-maxcapturerate*">
                                     <td><a>spropMaxCaptureRate</a></td>
@@ -2954,39 +2954,15 @@ mySignaller.myOfferTracks({
                                         <code>unsigned long</code>
                                     </td>
                                     <td>Receiver</td>
-                                    <td>A hint about the maximum input sampling rate that the sender is likely to produce.</td>
+                                    <td>The maximum input sampling rate produced by the sender.</td>
                                 </tr>
-                                <tr id="sec-ptime*">
+                                <tr id="sec-opus-ptime*">
                                     <td><a>ptime</a></td>
                                     <td>
                                         <code>unsigned long</code>
                                     </td>
                                     <td>Sender</td>
-                                    <td>The preferred duration of media represented by a packet that a decoder wants to receive in milliseconds.</td>
-                                </tr>
-                                <tr id="sec-maxaveragebitrate*">
-                                    <td><a>maxAverageBitrate</a></td>
-                                    <td>
-                                        <code>unsigned long</code>
-                                    </td>
-                                    <td>Sender</td>
-                                    <td>Specifies the maximum average receive bitrate of a session in bits per second (bits/s).</td>
-                                </tr>
-                                <tr id="sec-stereo*">
-                                    <td><a>stereo</a></td>
-                                    <td>
-                                        <code>boolean</code>
-                                    </td>
-                                    <td>Sender</td>
-                                    <td>Specifies whether the decoder prefers receiving stereo (if true) or mono signals (if false).</td>
-                                </tr>
-                                <tr id="sec-spropstereo*">
-                                    <td><a>spropStereo</a></td>
-                                    <td>
-                                        <code>boolean</code>
-                                    </td>
-                                    <td>Receiver</td>
-                                    <td>Specifies whether the sender is likely to produce stereo audio (if true) or mono signals (if false).</td>
+                                    <td>The duration of media represented by a packet that the encoder will produce in milliseconds.</td>
                                 </tr>
                                 <tr id="sec-cbr*">
                                     <td><a>cbr</a></td>
@@ -2994,7 +2970,7 @@ mySignaller.myOfferTracks({
                                         <code>boolean</code>
                                     </td>
                                     <td>Sender</td>
-                                    <td>Specifies if the decoder prefers the use of constant bitrate (if true) or variable bitrate (if false).</td>
+                                    <td>Specifies if the encoder is configured to generate constant bitrate (if true) or variable bitrate (if false).</td>
                                 </tr>
                                 <tr id="sec-useinbandfec*">
                                     <td><a>useInbandFec</a></td>
@@ -3002,7 +2978,7 @@ mySignaller.myOfferTracks({
                                         <code>boolean</code>
                                     </td>
                                     <td>Sender</td>
-                                    <td>Specifies if the decoder has the capability to take advantage of Opus in-band fec (if true) or not (if false).</td>
+                                    <td>Specifies if the encoder is configured to generate Opus in-band fec (if true) or not (if false).</td>
                                 </tr>
                                 <tr id="sec-usedtx*">
                                     <td><a>useDtx</a></td>
@@ -3010,7 +2986,7 @@ mySignaller.myOfferTracks({
                                         <code>boolean</code>
                                     </td>
                                     <td>Sender</td>
-                                    <td>Specifies if the decoder prefers the use of DTX (if true) or not (if false).</td>
+                                    <td>Specifies if the encoder is configured to use DTX (if true) or not (if false).</td>
                                 </tr>
                                 <tr id="sec-complexity*">
                                     <td><a>complexity</a></td>


### PR DESCRIPTION
https://github.com/openpeer/ortc/issues/258

Changes: 
Removed stereo and spropStero capabilities and settings (can be handled by maxChannels, numChannels)
Removed maxAverageBitrate setting (can be handled via RTCRtpEncodingParameters.maxBitrate)
Removed ptime (should be handled in RTCRtpCodecCapability and RTCRtpCodecParameters)
Changed wording of other settings to clarify meaning