### PR TITLE
rtpunhandled event prior to calling receive()

### DIFF
--- a/ortc.html
+++ b/ortc.html
@@ -5867,7 +5867,7 @@ RTCRtpParameters function myCapsToRecvParams(RTCRtpCapabilities recvCaps, RTCRtp
                 <h3>Changes since 20 November 2015</h3>
                 <ol>
                     <li>
-                        Added clarification where <code>rtpunhandled</code> event occurs prior to calling <code>receive()</code>, as noted in::
+                        Added clarification where <code>unhandledrtp</code> event occurs prior to calling <code>receive()</code>, as noted in::
                         <a href="https://github.com/openpeer/ortc/issues/243">Issue 243</a>
                     </li>
                     <li>

--- a/ortc.html
+++ b/ortc.html
@@ -2400,7 +2400,7 @@ mySignaller.myOfferTracks({
                         <p>
                             The value of the <a>MID</a> RTP header extension [[!BUNDLE]] in the RTP stream
                             triggering the <code><a>unhandledrtp</a></code> event.
-                            If <code>receiver.receive()</code> has not been called, the <a>MID</a> header
+                            If <code>receive()</code> has not been called, the <a>MID</a> header
                             extension cannot be decoded, so that <var>muxId</var> will be unset.
                         </p>
                     </dd>
@@ -2409,7 +2409,7 @@ mySignaller.myOfferTracks({
                         <p>
                             The value of the <a>RID</a> RTP header extension [[!RID]] in the RTP stream
                             triggering the <code><a>unhandledrtp</a></code> event.
-                            If <code>receiver.receive()</code> has not been called, the <a>RID</a> header
+                            If <code>receive()</code> has not been called, the <a>RID</a> header
                             extension cannot be decoded, so that <var>rid</var> will be unset.
                         </p>
                     </dd>

--- a/ortc.html
+++ b/ortc.html
@@ -5867,7 +5867,7 @@ RTCRtpParameters function myCapsToRecvParams(RTCRtpCapabilities recvCaps, RTCRtp
                 <h3>Changes since 20 November 2015</h3>
                 <ol>
                     <li>
-                        Added exception where <code><a>RTCRtpListener</a></code> is constructed prior to calling <code>receive()</code>, as noted in::
+                        Added clarification where <code>rtpunhandled</code> event occurs prior to calling <code>receive()</code>, as noted in::
                         <a href="https://github.com/openpeer/ortc/issues/243">Issue 243</a>
                     </li>
                     <li>

--- a/ortc.html
+++ b/ortc.html
@@ -2285,8 +2285,8 @@ mySignaller.myOfferTracks({
             </section>
             <section id="rtcrtplistener-operation*">
                 <h3>Operation</h3>
-                <p>
-                    An <a>RTCRtpListener</a> instance is constructed from an <code><a>RTCDtlsTransport</a></code> object.
+                <p()
+                    An <code><a>RTCRtpListener</a></code> instance is constructed from an <code><a>RTCDtlsTransport</a></code> object.
                 </p>
             </section>
             <section id="rtpmatchingrules*">
@@ -2400,6 +2400,8 @@ mySignaller.myOfferTracks({
                         <p>
                             The value of the <a>MID</a> RTP header extension [[!BUNDLE]] in the RTP stream
                             triggering the <code><a>unhandledrtp</a></code> event.
+                            If <code>receiver.receive()</code> has not been called, the <a>MID</a> header
+                            extension cannot be decoded, so that <var>muxId</var> will be unset.
                         </p>
                     </dd>
                     <dt>readonly attribute DOMString rid</dt>
@@ -2407,6 +2409,8 @@ mySignaller.myOfferTracks({
                         <p>
                             The value of the <a>RID</a> RTP header extension [[!RID]] in the RTP stream
                             triggering the <code><a>unhandledrtp</a></code> event.
+                            If <code>receiver.receive()</code> has not been called, the <a>RID</a> header
+                            extension cannot be decoded, so that <var>rid</var> will be unset.
                         </p>
                     </dd>
                     <dt>readonly attribute payloadtype payloadType</dt>
@@ -5862,6 +5866,10 @@ RTCRtpParameters function myCapsToRecvParams(RTCRtpCapabilities recvCaps, RTCRtp
             <section id="since-20-November-2015*">
                 <h3>Changes since 20 November 2015</h3>
                 <ol>
+                    <li>
+                        Added exception where <code><a>RTCRtpListener</a></code> is constructed prior to calling <code>receive()</code>, as noted in::
+                        <a href="https://github.com/openpeer/ortc/issues/243">Issue 243</a>
+                    </li>
                     <li>
                         Added support for ptime, as noted in:
                         <a href="https://github.com/openpeer/ortc/issues/160">Issue 160</a>


### PR DESCRIPTION
If an RtpListener is constructed prior to calling receiver.receive(parameters), RTP header extensions cannot be interpreted.  This prevents the rtpunhandled event from providing the MID or RID. 

Fix for Issue https://github.com/openpeer/ortc/issues/243