### PR TITLE
Make RFC 5322 normative

### DIFF
--- a/ortc.html
+++ b/ortc.html
@@ -5478,7 +5478,7 @@ function processStats(currentReport) {
                     <dt>DOMString name</dt>
                     <dd>
                         <p>
-                            A representation of the verified peer identity conforming to [[RFC5322]].
+                            A representation of the verified peer identity conforming to [[!RFC5322]].
                             This identity will have been verified via the
                             procedures described in [[!RTCWEB-SECURITY-ARCH]].
                         </p>


### PR DESCRIPTION
Fix yet another broken non-normative link by making it normative. 

Related to Issue https://github.com/openpeer/ortc/issues/353