### PR TITLE
WebRTC 1.0 as normative reference

### DIFF
--- a/ortc.html
+++ b/ortc.html
@@ -5944,7 +5944,7 @@ function signalAssertion(assertion) {
         <section class="informative" id="webrtc-compat*">
             <h2>WebRTC 1.0 Compatibility</h2>
             <p>
-                It is a goal of the ORTC API to provide the functionality of the WebRTC 1.0 API [[WEBRTC10]], as well as to enable the
+                It is a goal of the ORTC API to provide the functionality of the WebRTC 1.0 API [[!WEBRTC10]], as well as to enable the
                 WebRTC 1.0 API to be implemented on top of the ORTC API, utilizing a Javascript "shim" library. This section
                 discusses WebRTC 1.0 compatibility issues that have been encountered by ORTC API implementers.
             </p>
@@ -5963,7 +5963,7 @@ function signalAssertion(assertion) {
             <section id="voice-activity*">
                 <h3>Voice Activity Detection</h3>
                 <p>
-                    [[WEBRTC10]] Section 4.2.4 defines the <code>RTCOfferOptions</code> dictionary, which includes the <var>voiceActivityDetection</var> attribute,
+                    [[!WEBRTC10]] Section 4.2.4 defines the <code>RTCOfferOptions</code> dictionary, which includes the <var>voiceActivityDetection</var> attribute,
                     which determines whether Voice Activity Detection (VAD) is enabled within the Offer produced by <code>createOffer()</code>.
                     The effect of setting <var>voiceActivityDetection</var> to <var>true</var> is to include the Comfort Noice (CN) codec defined in
                     [[!RFC3389]] within the Offer.

--- a/ortc.html
+++ b/ortc.html
@@ -6132,7 +6132,10 @@ RTCRtpParameters function myCapsToRecvParams(RTCRtpCapabilities recvCaps, RTCRtp
                     </li>
                     <li>
                         Fixed markup issues in respec, as noted in:
-                        <a href="https://github.com/openpeer/ortc/issues/345">Issue 345</a> and
+                        <a href="https://github.com/openpeer/ortc/issues/345">Issue 345</a>
+                    </li>
+                    <li>
+                        Addressed issues with document anchor links, as noted in:
                         <a href="https://github.com/openpeer/ortc/issues/353">Issue 353</a>
                     </li>
                     </li>


### PR DESCRIPTION
Portions of the ORTC API are derived from WebRTC 1.0, including the sections on Data Channel, DTMF and Identity.  Therefore it is proposed that the WebRTC 1.0 API be made a normative reference.  This change also addresses Issue https://github.com/openpeer/ortc/issues/353